### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-styled-components",
   "version": "1.6.3",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-styled-components",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-styled-components#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-styled-components/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add the package homepage pointing to the repository README
- add the package bugs URL pointing to GitHub issues

## Validation
- `node -e "const p=require('./package.json'); if (p.homepage !== 'https://github.com/rstackjs/rsbuild-plugin-styled-components#readme') throw new Error('homepage mismatch'); if (!p.bugs || p.bugs.url !== 'https://github.com/rstackjs/rsbuild-plugin-styled-components/issues') throw new Error('bugs url mismatch'); console.log(JSON.stringify({name:p.name, homepage:p.homepage, bugs:p.bugs.url}, null, 2));"`
- `npm view @rsbuild/plugin-styled-components@latest name version repository.url homepage bugs --json`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`